### PR TITLE
lifecycle policy: change committers list from initial to current

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-project-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-project-proposal.md
@@ -37,9 +37,9 @@ assignees: ''
 
 11. Please describe your release methodology and mechanics
 
-12. Please list the names of the project's initial committers
+12. Please list the project's leadership team
 
-13. Please list the project's leadership team
+13. Please list the project members with access to commit to the mainline of the project
 
 14. Please describe the project's decision-making process
 

--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -26,8 +26,8 @@ Projects must be formally proposed via GitHub. Project proposals submitted to th
 * issue tracker (e.g., GitHub, Gitlab)
 * external dependencies (including licenses)
 * release methodology and mechanics
-* names of initial committers, if different from those submitting proposal
 * brief description of current leadership team and decision-making process
+* list of the project members with access to commit to the mainline of the project
 * link to any documented governance practices
 * list of project's official communication channels (E.g., slack, irc, mailing lists)
 * link to project's website


### PR DESCRIPTION
Update lifecycle policy document and github issue template to require a list of current committers to the project rather than initial committers.

A committer is someone with the "commit bit" access to modify the mainline of the project.