### PR TITLE
Project Proposal Template: 2 Sponsors

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-project-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-project-proposal.md
@@ -27,7 +27,7 @@ assignees: ''
 
 [Project Governance](https://www.projectgovernance.org)
 
-7. Sponsor from the High Performance Software Foundation's Technical Advisory Committee
+7. Two Sponsors from the High Performance Software Foundation's Technical Advisory Committee
 
 8. What is the project's solution for source control?
 


### PR DESCRIPTION
Reflect the lifecycle policy document in the template and guide new projects to add two sponsors.

At the moment, sponsors have to be voting members of the HPSF TAC and have a mentor/shephearding role for the project.