### PR TITLE
Update application steps to clarify that documented governance is necessary

### DIFF
--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -28,7 +28,7 @@ Projects must be formally proposed via GitHub. Project proposals submitted to th
 * release methodology and mechanics
 * brief description of current leadership team and decision-making process
 * list of the project members with access to commit to the mainline of the project
-* link to any documented governance practices
+* link to a documented governance practice
 * list of project's official communication channels (E.g., slack, irc, mailing lists)
 * link to project's website
 * links to social media accounts
@@ -77,6 +77,7 @@ To be considered for the Sandbox Stage, the project must meet the following requ
 * Submit a proposal for membership and present it at a meeting of the TAC
 * Have a charter document with an intellectual property policy that leverages open licenses, including, in the case of contributions of code, the use of one or more licenses approved as “open” by the Open Source Initiative.  The staff of the High Performance Software Foundation can assist projects in preparing a technical charter following the High Performance Software Foundation’s standard template.
 * Have a code of conduct (part of default governance for LF – there is a template)
+* Have a publicly available governance document — even if your governance is somewhat ad hoc, state what it is, including the project's technical leadership and roles
 * Upon acceptance, projects must list their status prominently on their website/README
 
 


### PR DESCRIPTION
Adjust language in lifecycle_policy.md to clarify that a documented governance policy is required for application to any stage of HPSF.  We were unaware of this until the presentation of our application, so the hope here is to help avoid surprise for future applicants.

Resolves #24
