### PR TITLE
The TAC does not vote on Linux Foundation requirements

### DIFF
--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -72,7 +72,6 @@ End users should evaluate Sandbox projects with care, as this stage does not set
 **Acceptance Criteria**
 
 To be considered for the Sandbox Stage, the project must meet the following requirements:
-* Meet all requirements to be a [Linux Foundation project](https://www.linuxfoundation.org/projects/hosting)
 * Have 2 TAC sponsors to champion the project & provide mentorship as needed
 * Submit a proposal for membership and present it at a meeting of the TAC
 * Have a charter document with an intellectual property policy that leverages open licenses, including, in the case of contributions of code, the use of one or more licenses approved as “open” by the Open Source Initiative.  The staff of the High Performance Software Foundation can assist projects in preparing a technical charter following the High Performance Software Foundation’s standard template.


### PR DESCRIPTION
The Technical Advisory Council does not vote on The Linux Foundation project requirements. The Linux Foundation will enact and enforce their requirements when they onboard the project.