### PR TITLE
The TAC does not vote on project charters

### DIFF
--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -75,7 +75,6 @@ To be considered for the Sandbox Stage, the project must meet the following requ
 * Meet all requirements to be a [Linux Foundation project](https://www.linuxfoundation.org/projects/hosting)
 * Have 2 TAC sponsors to champion the project & provide mentorship as needed
 * Submit a proposal for membership and present it at a meeting of the TAC
-* Have a charter document with an intellectual property policy that leverages open licenses, including, in the case of contributions of code, the use of one or more licenses approved as “open” by the Open Source Initiative.  The staff of the High Performance Software Foundation can assist projects in preparing a technical charter following the High Performance Software Foundation’s standard template.
 * Have a code of conduct (part of default governance for LF – there is a template)
 * Have a publicly available governance document — even if your governance is somewhat ad hoc, state what it is, including the project's technical leadership and roles
 * Upon acceptance, projects must list their status prominently on their website/README


### PR DESCRIPTION
The project charter is a Linux Foundation requirement that The Linux Foundation will enact and enforce when they onboard the project. Some projects do not have a charter yet when the TAC votes on their project proposal. Lack of a charter should not prevent the TAC from conditionally approving a project.