### PR TITLE
Updates to project proposal process

### DIFF
--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -63,15 +63,11 @@ Once a project has submitted a proposal as outlined above, the process for accep
 
    A project is accepted at the *lowest* level for which a 2/3 majority is achieved. For example, if there are 5 accepts for the "core" level, 1 accept for "established", and 3 rejects, the project is accepted at the "established" level as there were 6 votes for "established" or higher.
 
-7. To determine a majority, we use Robert's rules of Order. Under these rules, abstentions are counted as neither "yes" nor "no" votes and do not affect the outcome of the vote. They are recorded and noted, but not included in the calculation of a majority. In more detail:
+7. Vote Aggregation Rules
 
-   a. Right to Abstain: Members have the right to abstain from voting.
-   a. Not a Vote: Abstentions are not considered a vote in favor or against a motion.
-   b. Recorded, but Not Included: Abstentions are documented in the meeting minutes, but they are not part of the total votes cast when determining if a majority or supermajority was achieved.
-   c. Impact on Quorum: Abstentions do not affect whether a quorum is present, which is the minimum number of members required to conduct business.
-   d. Majority Vote: A majority vote is typically defined as more than half of the votes cast, excluding abstentions and blank votes.
-
-Abstentions can stem from various reasons, such as a conflict of interest, neutrality, or simply not wanting to vote either way.
+   * If the number of votes cast (including explicit "Abstain" votes) is less than half of the number of voting TAC members, then the result of the poll is "Against".
+   * Otherwise, if the number of "Approve" votes is at least two thirds of the votes cast (not including explicit "Abstain" votes), then the result of the poll is "Approve".
+   * Otherwise, the result of the poll is "Against".
 
 8. If a project is accepted pending minor requirements, it is the sponsors' responsibility to make sure that the project accomplishes the requested changes. This could (and has in the past) included:
 

--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -18,7 +18,7 @@ This governance policy sets forth the proposal process for projects to be accept
 Projects must be formally proposed via GitHub. Project proposals submitted to the High Performance Software Foundation should provide the information listed in our
 [New Project Proposal Template](https://github.com/hpsfoundation/tac/blob/main/.github/ISSUE_TEMPLATE/new-project-proposal.md) to the best of their ability.
 
-The main most important requirement from the list is to find two sponsors for your
+An important requirement from the list is to find two sponsors for your
 proposal on the TAC, as the sponsors will be arguing for your acceptance to HPSF. You
 should be sure that the sponsors are familiar with your project and your reasons for
 wanting to join HPSF.
@@ -53,27 +53,26 @@ to HPSF is as follows:
 5. Project members shall present their proposal at the scheduled TAC meeting. This should take
    no more than 30 minutes, and it will typically involve an introduction to the project and
    a verbal explanation of alignment with HPSF and key elements of the proposal.
-   See links in the prior section to past project propsoals for links to past talks.
+   See links in the prior section to past project proposals for links to past talks.
 
 6. Once the project members have presented, voting members of the TAC shall convene a
    private session, and the project's sponsors shall discuss the project, its presentation,
    its proposal, and any questions the voting members have as to the evidence for
    onboarding criteria.
 
-   In the closed sessio, sponsors are expected to advocate for the projects to be
-   onboarded and to clarify any questions the TAC may have.
+   In the closed session, sponsors are expected to advocate for the project and to clarify any questions the TAC may have.
 
 7. After the private session, the TAC shall vote asynchronously before the next TAC
-   meeting on whehter or not to accept the project.
+   meeting on whether or not to accept the project.
 
-   **Projects must be accepted by a 2/3 majority of the TAC.*
+   **Projects must be accepted by a 2/3 majority of the TAC.**
 
    Generally, the TAC will vote on the proposed level and all lower levels
    simultaneously.
 
 8. The TAC may decide to:
    1. Accept the project as proposed;
-   2. Accept the project provisionally, pending chages;
+   2. Accept the project provisionally, pending changes;
    3. Accept the project at a lower level than proposed (given sufficient votes); or
    4. Reject the project.
 

--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -34,50 +34,77 @@ To see past project proposals, you can look at the closed issues in this reposit
 ### Project Acceptance Process
 Once a project has submitted a proposal as outlined above, the process for accepting them to HPSF is as follows:
 
-1. TAC sponsors shall read through the project proposal and ensure that all criteria for the project's requested level are addressed in the proposal.
+1. **Sponsor Review**
+
+   TAC sponsors shall read through the project proposal and ensure that all criteria for the project's requested level are addressed in the proposal.
    If insufficient evidence is presented for any of the criteria, the sponsors should work with the project to bolster the case, or to choose a different, more appropriate initial level.
 
-2. Once the proposal is in a suitable state, the sponsors shall propose it to the full TAC for onboarding, and the TAC shall decide on a future meeting to hear the presentation.
+2. **Sponsor Proposal**
 
-3. TAC voting members shall read the project's proposal and ensure that they are familiar with the state of the project to be onboarded *before* the onboarding presentation.
+    Once the proposal is in a suitable state, the sponsors shall propose it to the full TAC for onboarding, and the TAC shall decide on a future meeting to hear the presentation.
 
-4. Project members shall present their proposal at the scheduled TAC meeting.
+3. **TAC Preparation**
+
+   TAC voting members shall read the project's proposal and ensure that they are familiar with the state of the project to be onboarded *before* the onboarding presentation.
+
+4. **Presentation** 
+
+   Project members shall present their proposal at the scheduled TAC meeting.
    This should take no more than 30 minutes, to leave time for the TAC to privately discuss after the meeting.
    The presentation should include an introduction to the project and an explanation of alignment with HPSF and key elements of the proposal.
    See links in the prior section to past project proposals for links to past talks.
 
-5. Once the project members finish their presentation, voting members of the TAC shall convene a private session (e.g., by closing the teleconference to people not on the TAC).
+5. **Private Discussion**
+
+   Once the project members finish their presentation, voting members of the TAC shall convene a private session (e.g., by closing the teleconference to people not on the TAC).
    The project's sponsors shall discuss the project, its presentation, its proposal, and any questions the voting members have as to the evidence for onboarding criteria.
 
    In the closed session, sponsors are expected to advocate for the project and to clarify any questions the TAC may have.
 
-6. After the private session, the TAC shall vote asynchronously before the next TAC meeting on whether or not to accept the project.
+6. **Voting**
+
+   After the private session, the TAC shall vote asynchronously before the next TAC meeting on the criteria for acceptance of the project.
+
+   The ballot shall include items for each criterion of the proposed stage and for each criterion in all lower stages.
+   For each criterion, voting TAC members can choose "Accept", "Against", or "Abstain". There is a [sample ballot here](templates/ballot_template.md) that shows criteria for all levels.
+
+   The ballot shall also include an option to indicate that a project should be accepted provisionally.
 
    Votes for project acceptance should include options to:
    1. Accept the project at the proposed level;
    2. Accept the project at a lower level than proposed (the poll should list all lower levels as options);
    3. Accept provisionally at the proposed level, pending minor requirements; or
    4. Reject the project.
+   
+7. **Vote Aggregation Rules**
 
-   **Projects must be accepted by a 2/3 majority of the TAC.**
+   For a project to be accepted, the TAC must vote by 2/3 majority to accept all of the criteria for that stage *and* to accept all criteria for lower stages.
 
-   A project is accepted at the *lowest* level for which a 2/3 majority is achieved. For example, if there are 5 accepts for the "core" level, 1 accept for "established", and 3 rejects, the project is accepted at the "established" level as there were 6 votes for "established" or higher.
-
-7. Vote Aggregation Rules
+   These rules apply for all criteria on the ballot:
 
    * If the number of votes cast (including explicit "Abstain" votes) is less than half of the number of voting TAC members, then the result of the poll is "Against".
    * Otherwise, if the number of "Approve" votes is at least two thirds of the votes cast (not including explicit "Abstain" votes), then the result of the poll is "Approve".
    * Otherwise, the result of the poll is "Against".
 
-8. If a project is accepted pending minor requirements, it is the sponsors' responsibility to make sure that the project accomplishes the requested changes. This could (and has in the past) included:
+   A project is accepted at the *highest* level for which it achieves a 2/3 majority on all criteria. For example, if the project receives:
+   * 5 Accept votes and 4 Against votes for all criteria at the "established" level; and
+   *  6 accepts and 3 rejections for all criteria at the "emerging" level
 
-   a. adding a governance document to a repository.
-   b. adopting a Code of Conduct.
-   c. awaiting approval as a Linux Foundation project.
+   then the project is accepted at the "emerging" level as there was a 2/3 majority for "emerging" but not for "established".
+
+8. **Provisional acceptance**
+
+   If a project is accepted pending minor requirements, it is the sponsors' responsibility to make sure that the project accomplishes the requested changes. This could include (and has included in the past):
+
+   1. Adding a governance document to a repository;
+   2. Adopting a Code of Conduct; or
+   3. Awaiting approval as a Linux Foundation project.
 
    Requirements like this should be noted on the project proposal pull request, and an action item for sponsors to follow up should remain on the TAC agenda until the changes are satisfied.
 
-9. Once accepted, projects can apply for a different stage in HPSF via the Periodic Review Process.
+9. **Further Progression** 
+
+   Once accepted, projects can apply for a different stage in HPSF via the Periodic Review Process.
 
 ## III. Stages - Definitions & Expectations
 Every High Performance Software Foundation project has an associated maturity level.
@@ -85,7 +112,6 @@ Every High Performance Software Foundation project has an associated maturity le
 All projects may attend TAC meetings and contribute work regardless of their stage.
 
 ### Emerging Projects
-**Definition**
 
 Emerging projects are projects which the TAC believes are, or have the potential to be, important to the ecosystem of Technical Projects or the High Performance Software Foundation ecosystem as a whole. The Emerging stage provides a beneficial, neutral home for these projects. The Emerging stage is intended as a low barrier of entry to the HPSF, which fosters collaborative development and provides a path to deeper alignment with other HPSF projects via the graduation process.
 
@@ -114,7 +140,6 @@ To be considered for the Emerging Stage, the project must meet the following req
 
 
 ### Established Stage
-**Definition**
 
 The Established Stage is for projects that are major components of the High Performance Computing software ecosystem. Established Stage projects will receive mentorship from the TAC and are expected to actively develop their community of contributors, governance, project documentation, and other variables that factor into broad success and adoption.
 
@@ -143,7 +168,6 @@ To be considered for Established Stage, the project must meet the Emerging requi
 * Receive a 2/3 majority vote of the TAC to move to the Established Stage.
 
 ### Core Stage
-**Definition**
 
 The Core Stage is for projects that are on a sustaining cycle of development, maintenance, and long-term support. Core Stage projects are used commonly in production environments and have large, well-established project communities. Projects in the Core stage have a higher level of access to foundation resources. Projects will participate in the Periodic Review Process.
 
@@ -172,7 +196,6 @@ To graduate from Emerging or Established status, or for a new project to join as
 
 
 ### Emeritus Stage
-**Definition**
 
 Emeritus projects are projects which the maintainers feel have reached or are nearing end-of-life. Emeritus projects have contributed to the ecosystem, but are not recommended for modern development except in unusual circumstances, as other options are preferable. The Foundation appreciates the contributions of these projects and their communities, and the role they have played in moving the ecosystem forward.
 

--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -45,22 +45,22 @@ to HPSF is as follows:
    the full TAC for onboarding, and the TAC shall decide on a future meeting to
    hear the presentation.
 
-4. TAC voting members shall read the project's proposal and ensure that they are familiar
+3. TAC voting members shall read the project's proposal and ensure that they are familiar
    with the state of the project to be onboarded *before* the onboarding presentation.
 
-5. Project members shall present their proposal at the scheduled TAC meeting. This should take
+4. Project members shall present their proposal at the scheduled TAC meeting. This should take
    no more than 30 minutes, and it will typically involve an introduction to the project and
    a verbal explanation of alignment with HPSF and key elements of the proposal.
    See links in the prior section to past project proposals for links to past talks.
 
-6. Once the project members have presented, voting members of the TAC shall convene a
+5. Once the project members have presented, voting members of the TAC shall convene a
    private session, and the project's sponsors shall discuss the project, its presentation,
    its proposal, and any questions the voting members have as to the evidence for
    onboarding criteria.
 
    In the closed session, sponsors are expected to advocate for the project and to clarify any questions the TAC may have.
 
-7. After the private session, the TAC shall vote asynchronously before the next TAC
+6. After the private session, the TAC shall vote asynchronously before the next TAC
    meeting on whether or not to accept the project.
 
    **Projects must be accepted by a 2/3 majority of the TAC.**
@@ -68,7 +68,7 @@ to HPSF is as follows:
    Generally, the TAC will vote on the proposed level and all lower levels
    simultaneously.
 
-8. The TAC may decide to:
+7. The TAC may decide to:
    1. Accept the project as proposed;
    2. Accept the project provisionally, pending changes;
    3. Accept the project at a lower level than proposed (given sufficient votes); or

--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -41,10 +41,8 @@ to HPSF is as follows:
    project to bolster the case, or to choose a different, more appropriate initial
    level.
 
-2. Once the proposal is in a suitable state, the sponsors shall propose it to the full
-   TAC for onboarding, and the TAC shall vote on whether to hear the project's presentation.
-
-3. If the TAC votes to take up the proposal, the TAC shall decide on a future meeting to
+2. Once the proposal is in a suitable state, the sponsors shall propose it to
+   the full TAC for onboarding, and the TAC shall decide on a future meeting to
    hear the presentation.
 
 4. TAC voting members shall read the project's proposal and ensure that they are familiar

--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -32,54 +32,56 @@ To see past project proposals, you can look at the closed issues in this reposit
 * [Core Project Proposals](https://github.com/hpsfoundation/tac/issues?q=is%3Aissue%20state%3Aclosed%20label%3Alevel%3Acore)
 
 ### Project Acceptance Process
-Once a project has submitted a proposal as outlined above, the process for accepting them
-to HPSF is as follows:
+Once a project has submitted a proposal as outlined above, the process for accepting them to HPSF is as follows:
 
-1. TAC sponsors shall read through the project proposal and ensure that all criteria
-   for the project's requested level are addressed in the proposal. If insufficient
-   evidence is presented for any of the criteria, the sponsors should work with the
-   project to bolster the case, or to choose a different, more appropriate initial
-   level.
+1. TAC sponsors shall read through the project proposal and ensure that all criteria for the project's requested level are addressed in the proposal.
+   If insufficient evidence is presented for any of the criteria, the sponsors should work with the project to bolster the case, or to choose a different, more appropriate initial level.
 
-2. Once the proposal is in a suitable state, the sponsors shall propose it to
-   the full TAC for onboarding, and the TAC shall decide on a future meeting to
-   hear the presentation.
+2. Once the proposal is in a suitable state, the sponsors shall propose it to the full TAC for onboarding, and the TAC shall decide on a future meeting to hear the presentation.
 
-3. TAC voting members shall read the project's proposal and ensure that they are familiar
-   with the state of the project to be onboarded *before* the onboarding presentation.
+3. TAC voting members shall read the project's proposal and ensure that they are familiar with the state of the project to be onboarded *before* the onboarding presentation.
 
-4. Project members shall present their proposal at the scheduled TAC meeting. This should take
-   no more than 30 minutes, and it will typically involve an introduction to the project and
-   a verbal explanation of alignment with HPSF and key elements of the proposal.
+4. Project members shall present their proposal at the scheduled TAC meeting.
+   This should take no more than 30 minutes, to leave time for the TAC to privately discuss after the meeting.
+   The presentation should include an introduction to the project and an explanation of alignment with HPSF and key elements of the proposal.
    See links in the prior section to past project proposals for links to past talks.
 
-5. Once the project members have presented, voting members of the TAC shall convene a
-   private session, and the project's sponsors shall discuss the project, its presentation,
-   its proposal, and any questions the voting members have as to the evidence for
-   onboarding criteria.
+5. Once the project members finish their presentation, voting members of the TAC shall convene a private session (e.g., by closing the teleconference to people not on the TAC).
+   The project's sponsors shall discuss the project, its presentation, its proposal, and any questions the voting members have as to the evidence for onboarding criteria.
 
    In the closed session, sponsors are expected to advocate for the project and to clarify any questions the TAC may have.
 
-6. After the private session, the TAC shall vote asynchronously before the next TAC
-   meeting on whether or not to accept the project.
+6. After the private session, the TAC shall vote asynchronously before the next TAC meeting on whether or not to accept the project.
+
+   Votes for project acceptance should include options to:
+   1. Accept the project at the proposed level;
+   2. Accept the project at a lower level than proposed (the poll should list all lower levels as options);
+   3. Accept provisionally at the proposed level, pending minor requirements; or
+   4. Reject the project.
 
    **Projects must be accepted by a 2/3 majority of the TAC.**
 
-   Generally, the TAC will vote on the proposed level and all lower levels
-   simultaneously.
+   A project is accepted at the *lowest* level for which a 2/3 majority is achieved. For example, if there are 5 accepts for the "core" level, 1 accept for "established", and 3 rejects, the project is accepted at the "established" level as there were 6 votes for "established" or higher.
 
-7. The TAC may decide to:
-   1. Accept the project as proposed;
-   2. Accept the project provisionally, pending changes;
-   3. Accept the project at a lower level than proposed (given sufficient votes); or
-   4. Reject the project.
+7. To determine a majority, we use Robert's rules of Order. Under these rules, abstentions are counted as neither "yes" nor "no" votes and do not affect the outcome of the vote. They are recorded and noted, but not included in the calculation of a majority. In more detail:
 
-Vote majorities will be calculated as a percentage of the votes received. If a project
-is accepted pending changes, sponsors should make sure that the project accomplishes the
-requested changes (e.g., adding a governance document to a repository or adopting a Code
-of Conduct) and notify the TAC for final approval.
+   a. Right to Abstain: Members have the right to abstain from voting.
+   a. Not a Vote: Abstentions are not considered a vote in favor or against a motion.
+   b. Recorded, but Not Included: Abstentions are documented in the meeting minutes, but they are not part of the total votes cast when determining if a majority or supermajority was achieved.
+   c. Impact on Quorum: Abstentions do not affect whether a quorum is present, which is the minimum number of members required to conduct business.
+   d. Majority Vote: A majority vote is typically defined as more than half of the votes cast, excluding abstentions and blank votes.
 
-Once accepted, projects can apply for a different stage in HPSF via the Periodic Review Process.
+Abstentions can stem from various reasons, such as a conflict of interest, neutrality, or simply not wanting to vote either way.
+
+8. If a project is accepted pending minor requirements, it is the sponsors' responsibility to make sure that the project accomplishes the requested changes. This could (and has in the past) included:
+
+   a. adding a governance document to a repository.
+   b. adopting a Code of Conduct.
+   c. awaiting approval as a Linux Foundation project.
+
+   Requirements like this should be noted on the project proposal pull request, and an action item for sponsors to follow up should remain on the TAC agenda until the changes are satisfied.
+
+9. Once accepted, projects can apply for a different stage in HPSF via the Periodic Review Process.
 
 ## III. Stages - Definitions & Expectations
 Every High Performance Software Foundation project has an associated maturity level.

--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -15,38 +15,74 @@ Capitalized terms not otherwise defined in this Project Lifecycle Policy have th
 This governance policy sets forth the proposal process for projects to be accepted into the High Performance Software Foundation. The process is the same for both existing projects which seek to move into the High Performance Software Foundation and new projects to be formed within the High Performance Software Foundation.
 
 ### Project Proposal Requirements
-Projects must be formally proposed via GitHub. Project proposals submitted to the High Performance Software Foundation should provide the following information to the best of their ability:
+Projects must be formally proposed via GitHub. Project proposals submitted to the High Performance Software Foundation should provide the information listed in our
+[New Project Proposal Template](https://github.com/hpsfoundation/tac/blob/main/.github/ISSUE_TEMPLATE/new-project-proposal.md) to the best of their ability.
 
-* name of project
-* project description (what it does, why it is valuable, origin and history)
-* statement on alignment with the High Performance Software Foundation mission as expressed in the [HPSF Roles and Values](https://hpsf.io/#goals)
-* link to *current* Code of Conduct (if one is adopted already)
-* project license
-* source control (e.g., GitHub, Gitlab)
-* issue tracker (e.g., GitHub, Gitlab)
-* external dependencies (including licenses)
-* release methodology and mechanics
-* brief description of current leadership team and decision-making process
-* list of the project members with access to commit to the mainline of the project
-* link to a documented governance practice
-* list of project's official communication channels (E.g., slack, irc, mailing lists)
-* link to project's website
-* links to social media accounts
-* brief description of current user community
-* brief description of current contributor community
-* existing financial sponsorship and funding institutions
-* existing legal entity, if any
-* sponsor from the TAC, if identified (a sponsor helps mentor projects)
-* preferred project lifecycle stage to enter HPSF (see stages below)
-* infrastructure needs or requests (there will be opportunities to change this after joining HPSF)
+The main most important requirement from the list is to find two sponsors for your
+proposal on the TAC, as the sponsors will be arguing for your acceptance to HPSF. You
+should be sure that the sponsors are familiar with your project and your reasons for
+wanting to join HPSF.
+
+[Click this link](https://github.com/hpsfoundation/tac/issues/new?template=new-project-proposal.md) to start a new project proposal issue on GitHub.
+
+To see past project proposals, you can look at the closed issues in this repository. See here:
+
+* [Emerging Project Proposals](https://github.com/hpsfoundation/tac/issues?q=is%3Aissue%20state%3Aclosed%20label%3Alevel%3Aemerging)
+* [Established Project Proposals](https://github.com/hpsfoundation/tac/issues?q=is%3Aissue%20state%3Aclosed%20label%3Alevel%3Aestablished)
+* [Core Project Proposals](https://github.com/hpsfoundation/tac/issues?q=is%3Aissue%20state%3Aclosed%20label%3Alevel%3Acore)
 
 ### Project Acceptance Process
-* Projects are required to present their proposal at a TAC meeting
-* The TAC may ask for changes to bring the project into better alignment with the High Performance Software Foundation (adding a governance document to a repository or adopting a Code of Conduct, for example).
-* The project will need to make these changes in order to progress further.
-* Projects are accepted by a 2/3 majority of the TAC.
-* Vote majorities will be calculated as a percentage of the votes received
-* The TAC will determine the appropriate initial stage for the project. The project can apply for a different stage via the Periodic Review Process.
+Once a project has submitted a proposal as outlined above, the process for accepting them
+to HPSF is as follows:
+
+1. TAC sponsors shall read through the project proposal and ensure that all criteria
+   for the project's requested level are addressed in the proposal. If insufficient
+   evidence is presented for any of the criteria, the sponsors should work with the
+   project to bolster the case, or to choose a different, more appropriate initial
+   level.
+
+2. Once the proposal is in a suitable state, the sponsors shall propose it to the full
+   TAC for onboarding, and the TAC shall vote on whether to hear the project's presentation.
+
+3. If the TAC votes to take up the proposal, the TAC shall decide on a future meeting to
+   hear the presentation.
+
+4. TAC voting members shall read the project's proposal and ensure that they are familiar
+   with the state of the project to be onboarded *before* the onboarding presentation.
+
+5. Project members shall present their proposal at the scheduled TAC meeting. This should take
+   no more than 30 minutes, and it will typically involve an introduction to the project and
+   a verbal explanation of alignment with HPSF and key elements of the proposal.
+   See links in the prior section to past project propsoals for links to past talks.
+
+6. Once the project members have presented, voting members of the TAC shall convene a
+   private session, and the project's sponsors shall discuss the project, its presentation,
+   its proposal, and any questions the voting members have as to the evidence for
+   onboarding criteria.
+
+   In the closed sessio, sponsors are expected to advocate for the projects to be
+   onboarded and to clarify any questions the TAC may have.
+
+7. After the private session, the TAC shall vote asynchronously before the next TAC
+   meeting on whehter or not to accept the project.
+
+   **Projects must be accepted by a 2/3 majority of the TAC.*
+
+   Generally, the TAC will vote on the proposed level and all lower levels
+   simultaneously.
+
+8. The TAC may decide to:
+   1. Accept the project as proposed;
+   2. Accept the project provisionally, pending chages;
+   3. Accept the project at a lower level than proposed (given sufficient votes); or
+   4. Reject the project.
+
+Vote majorities will be calculated as a percentage of the votes received. If a project
+is accepted pending changes, sponsors should make sure that the project accomplishes the
+requested changes (e.g., adding a governance document to a repository or adopting a Code
+of Conduct) and notify the TAC for final approval.
+
+Once accepted, projects can apply for a different stage in HPSF via the Periodic Review Process.
 
 ## III. Stages - Definitions & Expectations
 Every High Performance Software Foundation project has an associated maturity level.

--- a/templates/ballot_template.md
+++ b/templates/ballot_template.md
@@ -1,0 +1,79 @@
+# Ballot 
+
+This is a template ballot for HPSF project acceptance.
+
+## Criteria for Emerging Stage
+
+1. That the project has 2 TAC sponsors.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+2. That the project aligns with the mission of the HPSF.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+3. That the project has a publicly available governance document.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+### Criteria for the Established Stage
+
+To be considered for Established Stage, the project must meet the Emerging requirements as well as the following:
+
+4. That the project is being used successfully in production by at least three independent end users which of adequate quality and scope.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+5. That the project has demonstrated development processes that lower barriers to contribution and ensure software quality necessary for increased adoption.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+6. That the project has demonstrated a substantial ongoing flow of commits and merged contributions.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+### Core Stage
+
+To graduate from Emerging or Established status, or for a new project to join as a Core project, a project must meet the Established stage criteria plus:
+
+7. That the project has a defined governing body of at least 4 or more members (owners and core maintainers), of whom no more than 1/2 are affiliated with the same employer.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+8. That the project has documented and publicly accessible description of the project's governance, decision-making, and release processes.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+9. That the project has a healthy number of committers from at least two organizations, where a committer is defined as someone accept contributions to some or all of the project.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+10. That the project has explicitly defined security reporting and incident mitigation processes, as appropriate to the security risks of the project.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+11. That the project has explicitly defined governance and committer processes.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+12. That the project has been widely adopted in the HPC ecosystem or in some important component thereof.
+    - [ ] Approve
+    - [ ] Against
+    - [ ] Abstain
+
+## Conditional Acceptance
+
+If a project meets the criteria for some level above by vote of the TAC, it will be accepted. Indicate here whether there are additional minor issues that must be addressed before acceptance.
+
+  - [ ] There are minor outstanding issues that the project must address before being accepted.


### PR DESCRIPTION
This is a new project proposal process as discussed in past TAC meetings.

The new process is designed to ensure that the TAC does due diligence and weighs the lifecycle criteria adequately when onboarding new projects to HPSF.

This process:
1. Adds a private session of the voting members of the TAC after each project onboarding presentation.
2. Expands the role of sponsors to advocate for projects in a private TAC session after each onboarding presentation.
3. Clarifies the voting aggregation criteria for approval of new projects
4. Adds a template ballot for voting