### PR TITLE
Clarify vote quorum requirements

### DIFF
--- a/lifecycle_policy.md
+++ b/lifecycle_policy.md
@@ -82,7 +82,7 @@ Once a project has submitted a proposal as outlined above, the process for accep
 
    These rules apply for all criteria on the ballot:
 
-   * If the number of votes cast (including explicit "Abstain" votes) is less than half of the number of voting TAC members, then the result of the poll is "Against".
+   * If the number of votes cast (including explicit "Abstain" votes) is not greater than half of the number of voting TAC members, then the result of the poll is "Against".
    * Otherwise, if the number of "Approve" votes is at least two thirds of the votes cast (not including explicit "Abstain" votes), then the result of the poll is "Approve".
    * Otherwise, the result of the poll is "Against".
 


### PR DESCRIPTION
In the TAC meeting on December 11, 2025, we had a poll result where 8 votes were cast and there are 16 voting TAC members, but we did not approve the resolution because of lack of quorum. It is not sufficient for the number of votes cast to be equal to half the number of voting TAC members. For a poll to meet the quorum requirement, the number of votes cast needs to be greater than half the number of voting TAC members.

Update the Project Lifecycle Policies to reflect that.