### PR TITLE
Update my affiliation from HPE to Chapel

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Emeritus projects are projects which the maintainers feel have reached or are ne
 
 * Andrew Myers (AMReX)
 * Axel Huebl (WarpX)
-* Brad Chamberlain (Hewlett Packard Enterprise Development LP)
+* Brad Chamberlain (Chapel)
 * Curtis Ober (Trilinos)
 * Damien Lebrun-Grandie (Kokkos)
 * Gregory Becker (Spack)


### PR DESCRIPTION
I noticed yesterday that I'd been added to the README with an HPE affiliation, which is accurate, but my role on the TAC is more connected to Chapel's project membership than HPE's HPSF membership, so this updates it to match how other project TAC representatives are listed.
